### PR TITLE
Upgrading ember-string-ishtmlsafe-polyfill

### DIFF
--- a/addon/services/adv-validation-manager.js
+++ b/addon/services/adv-validation-manager.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import AdvValidator from '../mixins/adv-validator';
 import configuration from '../configuration';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 class AwaitingValidation {
   constructor(dependsOn, validatorFn) {
@@ -487,7 +486,7 @@ export default Ember.Service.extend({
 
     if (Ember.isPresent(i18n)) {
       formatted = i18n.t(validationMessage);
-      if (isHTMLSafe(formatted)) {
+      if (Ember.String.isHTMLSafe(formatted)) {
         formatted = formatted.toString();
       }
     } else {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "2.11.0",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "loader.js": "^4.0.10"
   },
   "keywords": [


### PR DESCRIPTION
👋 -- We're updating [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) to be a "native polyfill". Following the pattern provided by [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5
